### PR TITLE
[skip ci][WIP]Show logs in futon

### DIFF
--- a/apps/couch_httpd/src/couch_httpd.erl
+++ b/apps/couch_httpd/src/couch_httpd.erl
@@ -621,7 +621,10 @@ http_1_0_keep_alive(Req, Headers) ->
     end.
 
 start_chunked_response(#httpd{mochi_req=MochiReq}=Req, Code, Headers) ->
-    log_request(Req, Code),
+    case couch_httpd:qs_value(Req, "log") of
+        "false" -> ok;
+        _ -> log_request(Req, Code)
+    end,
     couch_stats_collector:increment({httpd_status_codes, Code}),
     Headers1 = http_1_0_keep_alive(MochiReq, Headers),
     Headers2 = Headers1 ++ server_header() ++

--- a/share/www/_sidebar.html
+++ b/share/www/_sidebar.html
@@ -22,6 +22,7 @@ specific language governing permissions and limitations under the License.
       <li><a href="index.html">Overview</a></li>
       <li><a href="config.html">Configuration</a></li>
       <li><a href="replicator.html">Replicator</a></li>
+      <li><a href="logs.html">Logs</a></li>
       <li><a href="status.html">Status</a></li>
       <!-- <li><a href="plugins.html">Plugins</a></li> -->
     </ul></li>

--- a/share/www/logs.html
+++ b/share/www/logs.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<!--
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+-->
+<html lang="en">
+  <head>
+    <title>Logs</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link rel="stylesheet" href="style/layout.css?0.11.0" type="text/css">
+    <script src="script/json2.js"></script>
+    <script src="script/sha1.js"></script>
+    <script src="script/jquery.js"></script>
+    <script src="script/jquery.couch.js"></script>
+    <script src="script/futon.js"></script>
+    <script src="script/couch.js"></script>
+    <script>
+    	$(document).ready(function(){
+    		var previous_log = "";
+    		var last_read_log = "";
+        var stopped = false;
+        var started = false;
+    		$("#start").click(function(){
+    			if(started == false){
+            started = true;
+            stopped = false;
+            start_requests();
+          }
+          else if(stopped == true){
+            stopped = false;
+          }
+    		})
+
+    		start_requests = function(){
+    			$("#log_box").html("<strong>Started</strong>\n" + $("#log_box").html());
+    			setInterval(function(){ if(stopped!=true){ append_log(last_read()) }}, 2000);
+    		}
+
+    		last_read = function(){
+    			return last_read_log;
+    		}
+    		append_log = function(last_read){
+    			log = CouchDB.get_log(last_read).split("\n").reverse().join("\n");
+    			last_read_log = log.split("\n")[0];
+    			if(previous_log != log){
+    				$("#log_box").html(log + $("#log_box").html());
+    				previous_log = log;
+    			}
+    			else{
+    				return "";
+    			}
+    		}
+
+    		$("#stop").click(function(){
+    			stopped = true
+    			$("#log_box").html("<strong>Stopped</strong>\n" + $("#log_box").html())
+    		})
+
+    		$("#clear").click(function(){
+    			$("#log_box").html("<strong>Cleared</strong>");
+    		})
+    	})
+    </script>
+  </head>
+  <body><div id="wrap">
+    <h1>
+      <a href="index.html">Overview</a>
+      <strong>Logs</strong>
+    </h1>
+    <div id="content">
+    	<div id="controls">
+    		<a href="#" id="start">Start</a> |
+    		<a href="#" id="stop">Stop</a> | 
+    		<a href="#" id="clear">Clear</a> | 
+    	</div>
+    	<hr />
+    	<div id="log_box"></div>
+    </div>
+  </div></body>
+</html>

--- a/share/www/script/couch.js
+++ b/share/www/script/couch.js
@@ -437,6 +437,22 @@ CouchDB.requestStats = function(module, key, test) {
   return JSON.parse(stat)[module][key];
 };
 
+// this requests new log entries from the last read log entry
+CouchDB.get_log = function(last_read) {
+  options = "?log=false"
+  console.log(last_read)
+  if(last_read != ""){
+    options += ("&last_read=" + last_read)
+  }
+  CouchDB.last_req = CouchDB.request("GET", "/_log" + options);
+  CouchDB.maybeThrowError(CouchDB.last_req);  
+  return CouchDB.log_cleanup(CouchDB.last_req.response)
+}
+
+CouchDB.log_cleanup = function(log) {
+  return log.substring(log.indexOf("\n"), log.lastIndexOf("\n"))
+}
+
 CouchDB.uuids_cache = [];
 
 CouchDB.newUuids = function(n, buf) {

--- a/share/www/style/layout.css
+++ b/share/www/style/layout.css
@@ -624,3 +624,4 @@ form#replicator p.actions { padding: 1px; clear: left; margin: 0;
 #loginSignup {
   font-size:200%;
 }
+#log_box { height: 500px; overflow-y: scroll; white-space: pre-wrap}


### PR DESCRIPTION
Uses the couch_log read/1  and if a "last read" is provided, it automatically returns log entries after last_read log entry.

![futon_logs](https://cloud.githubusercontent.com/assets/5187494/13897322/a7781cac-edd3-11e5-8535-61c7b6b921e7.PNG)
