### PR TITLE
Return complete lines for _log

### DIFF
--- a/apps/couch/src/couch_log.erl
+++ b/apps/couch/src/couch_log.erl
@@ -22,7 +22,7 @@
 -export([debug/2, info/2, warn/2, error/2]).
 -export([debug_on/0, info_on/0, warn_on/0, get_level/0, get_level_integer/0, set_level/1]).
 -export([debug_on/1, info_on/1, warn_on/1, get_level/1, get_level_integer/1, set_level/2]).
--export([read/2]).
+-export([read/2, read/3]).
 
 % gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -257,6 +257,19 @@ read(Bytes, Offset) ->
     {ok, Chunk} = file:pread(Fd, Start, Bytes),
     ok = file:close(Fd),
     Chunk.
+
+% If formatted is set to true, then read/3 removes the first line, assuming it is not complete and returns the chunk
+
+read(Bytes, Offset, Formatted) ->
+    Chunk = read(Bytes, Offset),
+    case Formatted of
+        true -> truncate_first_line(Chunk);
+        _ -> Chunk
+    end.
+
+truncate_first_line(Chunk) ->
+    EndOfLine = string:chr(Chunk, $\n),
+    string:substr(Chunk, EndOfLine + 1).
 
 
 maybe_start_logfile_backend(Filename, Level) ->

--- a/apps/couch_httpd/src/couch_httpd_misc_handlers.erl
+++ b/apps/couch_httpd/src/couch_httpd_misc_handlers.erl
@@ -303,7 +303,8 @@ handle_log_req(#httpd{method='GET'}=Req) ->
     ok = couch_httpd:verify_is_server_admin(Req),
     Bytes = list_to_integer(couch_httpd:qs_value(Req, "bytes", "1000")),
     Offset = list_to_integer(couch_httpd:qs_value(Req, "offset", "0")),
-    Chunk = couch_log:read(Bytes, Offset),
+    % setting the 3rd params as true will truncate the first line in response to make sure only whole lines are returned
+    Chunk = couch_log:read(Bytes, Offset, true),
     {ok, Resp} = start_chunked_response(Req, 200, [
         % send a plaintext response
         {"Content-Type", "text/plain; charset=utf-8"},


### PR DESCRIPTION
read/3 has the 3rd argument as "Formatted"
If set to true, then it calls read/2 and truncates 1st line, else returns the exact data