### PR TITLE
WIP:  support batch updates via HTTP

### DIFF
--- a/apps/barrel_http/src/barrel_http_rest_docs.erl
+++ b/apps/barrel_http/src/barrel_http_rest_docs.erl
@@ -124,6 +124,11 @@ parse_header_match_id([DocId|Tail], Acc) ->
 
 route_all_docs(Req, #state{method= <<"GET">>, database=Database, docid=undefined}=State) ->
   barrel_http_rest_docs_list:get_resource(Database, Req, State);
+route_all_docs(
+  #{headers := #{<<"x-barrel-write-batch">> := <<"true">>}}=Req,
+  #state{method= <<"POST">>, docid=undefined}=State
+) ->
+  barrel_http_rest_docs_list:handle_write_batch(Req, State);
 route_all_docs(Req, State) ->
   barrel_http_rest_docs_id:handle(Req, State).
 

--- a/apps/barrel_http/src/barrel_http_rest_docs_list.erl
+++ b/apps/barrel_http/src/barrel_http_rest_docs_list.erl
@@ -18,6 +18,7 @@
 
 %% API
 -export([get_resource/3]).
+-export([handle_write_batch/2]).
 
 -include("barrel_http_rest_docs.hrl").
 
@@ -89,7 +90,87 @@ get_resource(Database, Req0, #state{idmatch=DocIds}=State) when is_list(DocIds) 
   {ok, Req, State}.
 
 
+handle_write_batch(Req, State) ->
+  {ok, Body, Req2} = cowboy_req:read_body(Req),
+  case Body of
+    <<>> ->
+      barrel_http_reply:error(400, <<"empty body">>, Req2, State);
+    Body ->
+      try jsx:decode(Body, [return_maps]) of Json ->
+        do_write_batch(Json, Req2, State)
+      catch
+        _:_ ->
+          barrel_http_reply:error(400, <<"malformed json document">>, Req2, State)
+      end
 
+  end.
+
+do_write_batch(Json, Req, State) ->
+  Async = case Req of
+            #{ headers := #{ <<"x-barrel-async">> := << "true">> }} -> true;
+            _ -> false
+          end,
+  
+  Ops = maps:get(<<"updates">>, Json),
+  InitBatch = barrel_write_batch:new(Async),
+  update_docs(Ops, InitBatch, Req, State).
+
+
+update_docs([Op | Rest], Batch, Req, State) ->
+  case parse_op(Op) of
+    {put, Obj, Rev} ->
+      Batch2 = barrel_write_batch:put(Obj, Rev, Batch),
+      update_docs(Rest, Batch2, Req, State);
+    {post, Obj, IsUpsert} ->
+      Batch2 = barrel_write_batch:post(Obj, IsUpsert, Batch),
+      update_docs(Rest, Batch2, Req, State);
+    {delete, Id, Rev} ->
+      Batch2 = barrel_write_batch:delete(Id, Rev, Batch),
+      update_docs(Rest, Batch2, Req, State);
+    {put_rev, Obj, History, Deleted} ->
+      Batch2 = barrel_write_batch:put_rev(Obj, History, Deleted, Batch),
+      update_docs(Rest, Batch2, Req, State);
+    error ->
+      barrel_http_reply:error(400, <<"invalid batch">>, Req, State)
+  end;
+update_docs([], Batch, Req, #state{database=Db}=State) ->
+  lager:info("batch is ~p~n", [Batch]),
+  case barrel_db:update_docs(Db, Batch) of
+    ok ->
+      barrel_http_reply:json(200, #{ <<"ok">> => true }, Req, State);
+    Results ->
+      JsonResults = [ batch_result(Result) || Result <- Results ],
+      JsonResp = #{ <<"ok">> => true, <<"results">> =>  JsonResults },
+      lager:info("results is ~p~n", [JsonResults]),
+      
+      barrel_http_reply:json(200, JsonResp, Req, State)
+  end.
+
+parse_op(#{ <<"op">> := <<"put">>, <<"doc">> := Doc} = OP) ->
+  Rev = maps:get(<<"rev">>, OP, <<>>),
+  {put, Doc, Rev};
+parse_op(#{ <<"op">> := <<"post">>, <<"doc">> := Doc} = OP) ->
+  IsUpsert = maps:get(<<"is_upsert">>, OP, false),
+  {post, Doc, IsUpsert};
+parse_op(#{ <<"op">> := <<"delete">>, <<"id">> := DocId} = OP) ->
+  Rev = maps:get(<<"rev">>, OP, <<>>),
+  {delete, DocId, Rev};
+parse_op(#{ <<"op">> := <<"put_rev">>, <<"doc">> := Doc, <<"history">> := History} = OP) ->
+  Deleted = maps:get(<<"deleted">>, OP, false),
+  {put_rev, Doc, History, Deleted};
+parse_op(_) ->
+  error.
+
+batch_result({ok, Id, Rev}) ->
+  #{ <<"status">> => <<"ok">>, <<"id">> => Id, <<"rev">> => Rev};
+batch_result({error, not_found}) ->
+  #{ <<"status">> => <<"error">>, <<"reason">> => <<"not found">>};
+batch_result({error, {conflict, doc_exists}}) ->
+  #{ <<"status">> => <<"conflict">>, <<"reason">> => <<"doc exists">>};
+batch_result({error, {conflict, revision_conflict}}) ->
+  #{ <<"status">> => <<"conflict">>, <<"reason">> => <<"revision conflict">>};
+batch_result({error, Reason}) ->
+  #{ <<"status">> => <<"error">>, <<"reason">> => Reason}.
 
 parse_params(Req) ->
   Params = cowboy_req:parse_qs(Req),

--- a/apps/barrel_httpc/src/barrel_httpc.erl
+++ b/apps/barrel_httpc/src/barrel_httpc.erl
@@ -26,6 +26,7 @@
   delete/3,
   update_with/4,
   put_rev/5,
+  write_batch/3,
   fold_by_id/4,
   fold_by_path/5,
   changes_since/5,
@@ -85,6 +86,31 @@
 
 -type attachment() :: {atom(), any()}.
 
+-type batch_options() :: [
+{async, boolean()}
+].
+
+-type batch_results() :: [
+  {ok, docid(), revid()}
+  | {error, not_found}
+  | {error, {conflict, doc_exists}}
+  | {error, {conflict, revision_conflict}}
+  | {error, any()}
+].
+
+-type batch_op() ::
+  {put, Doc :: barrel_local:doc()} |
+  {put, Doc :: barrel_local:doc(), Rev :: barrel_local:revid()} |
+  {put, Doc :: barrel_local:doc(), Attachments :: [attachment()]} |
+  {put, Doc :: barrel_local:doc(), Attachments :: [attachment()], Rev :: barrel_local:revid()} |
+  {post, Doc :: barrel_local:doc()} |
+  {post, Doc :: barrel_local:doc(), IsUpsert :: boolean()} |
+  {post, Doc :: barrel_local:doc(), Attachments :: [attachment()]} |
+  {post, Doc :: barrel_local:doc(), Attachments :: [attachment()], IsUpsert :: boolean()} |
+  {delete, DocId :: barrel_local:docid(), Rev :: barrel_local:revid()} |
+  {put_rev, Doc :: barrel_local:doc(), History :: list(), Deleted :: boolean()} |
+  {put_rev, Doc :: barrel_local:doc(), Attachments :: [attachment()], History :: list(), Deleted :: boolean()}.
+
 -export_type([
   conn/0,
   docid/0,
@@ -96,7 +122,10 @@
   fold_options/0,
   revid/0,
   revtree/0,
-  change/0
+  change/0,
+  batch_options/0,
+  batch_results/0,
+  batch_op/0
 ]).
 
 
@@ -520,6 +549,83 @@ put_rev(Conn, #{ <<"id">> := DocId } = Doc, History, Deleted, _Options) ->
     Error -> Error
   end;
 put_rev(_, _, _, _, _) -> erlang:error({bad_doc, invalid_docid}).
+
+%% @doc Apply the specified updates to the database.
+%% Note: The batch is not guaranteed to be atomic, atomicity is only guaranteed at the doc level.
+-spec write_batch(Conn, Updates, Options) -> Results when
+  Conn :: conn(),
+  Updates :: [batch_op()],
+  Options :: batch_options(),
+  Results :: batch_results().
+write_batch(Conn, Updates, Options) ->
+  Async = proplists:get_value(async, Options, false),
+  Headers = [ {<<"Content-Type">>, <<"application/json">>},
+              {<<"x-barrel-write-batch">>, <<"true">>},
+              {<<"x-barrel-async">>, Async }],
+  Url = barrel_httpc_lib:make_url(Conn, [<<"docs">>], []),
+  JsonUpdate = [batch_update(Update) || Update <- Updates],
+  Body = jsx:encode(#{ <<"updates">> => JsonUpdate }),
+  case request(Conn, <<"POST">>, Url, Headers, Body) of
+    {ok, Status, _RespHeaders, JsonBody}=Resp ->
+      case lists:member(Status, [200]) of
+        true ->
+          Json = jsx:decode(JsonBody, [return_maps]),
+          case maps:find(<<"results">>, Json) of
+            {ok, Results} ->
+              [ batch_result(Res) || Res <- Results ];
+            error ->
+              ok
+          end;
+        false ->
+          {error, {bad_response, Resp}}
+      end;
+    Error -> Error
+  end.
+
+batch_update({post, Doc}) when is_map(Doc) ->
+  #{ <<"op">> => <<"post">>, <<"doc">> => Doc };
+batch_update({post, Doc0, Attachments}) when is_map(Doc0), is_list(Attachments) ->
+  {ok, Doc1} = encode_attachments(Doc0, Attachments),
+  #{ <<"op">> => <<"post">>, <<"doc">> => Doc1 };
+batch_update({post, Doc, IsUpsert}) when is_map(Doc), is_boolean(IsUpsert) ->
+  #{ <<"op">> => <<"post">>, <<"doc">> => Doc, <<"is_upsert">> => IsUpsert };
+batch_update({post, Doc0, Attachments,  IsUpsert}) when is_map(Doc0), is_list(Attachments), is_boolean(IsUpsert) ->
+  {ok, Doc1} = encode_attachments(Doc0, Attachments),
+  #{ <<"op">> => <<"post">>, <<"doc">> => Doc1, <<"is_upsert">> => IsUpsert };
+batch_update({put, Doc}) when is_map(Doc) ->
+  #{ <<"op">> => <<"put">>, <<"doc">> => Doc };
+batch_update({put, Doc0, Attachments}) when is_map(Doc0), is_list(Attachments) ->
+  {ok, Doc1} = encode_attachments(Doc0, Attachments),
+  #{ <<"op">> => <<"put">>, <<"doc">> => Doc1 };
+batch_update({put, Doc, Rev}) when is_map(Doc), is_binary(Rev) ->
+  #{ <<"op">> => <<"put">>, <<"doc">> => Doc, <<"rev">> => Rev };
+batch_update({put, Doc0, Attachments, Rev}) when is_map(Doc0), is_list(Attachments), is_binary(Rev) ->
+  {ok, Doc1} = encode_attachments(Doc0, Attachments),
+  #{ <<"op">> => <<"put">>, <<"doc">> => Doc1, <<"rev">> => Rev };
+batch_update({delete, DocId}) when is_binary(DocId) ->
+  #{ <<"op">> => <<"delete">>, <<"id">> => DocId };
+batch_update({delete, DocId, Rev}) when is_binary(DocId), is_binary(Rev) ->
+  #{ <<"op">> => <<"delete">>, <<"id">> => DocId, <<"rev">> => Rev };
+batch_update({put_rev, Doc, History, Deleted}) when is_binary(Doc), is_binary(History), is_boolean(Deleted) ->
+  #{ <<"op">> => <<"put_rev">>, <<"doc">> => Doc, <<"history">> => History, <<"deleted">> => Deleted };
+batch_update(
+  {put_rev, Doc0, Attachments, History, Deleted}
+) when is_binary(Doc0), is_list(Attachments), is_binary(History), is_boolean(Deleted) ->
+  {ok, Doc1} = encode_attachments(Doc0, Attachments),
+  #{ <<"op">> => <<"put_rev">>, <<"doc">> => Doc1, <<"history">> => History, <<"deleted">> => Deleted };
+batch_update(_) ->
+  erlang:error(badarg).
+
+batch_result(#{ <<"status">> := <<"ok">>, <<"id">> := DocId, <<"rev">> := Rev }) ->
+  {ok, DocId, Rev};
+batch_result(#{ <<"status">> := <<"error">>, <<"reason">> := <<"not found">> }) ->
+  {error, not_found};
+batch_result(#{ <<"status">> := <<"error">>, <<"reason">> := Other }) ->
+  {error, Other};
+batch_result(#{ <<"status">> := <<"conflict">>, <<"reason">> := <<"doc exists">> }) ->
+  {error, {conflict, doc_exists}};
+batch_result(#{ <<"status">> := <<"conflict">>, <<"reason">> := <<"revision conflict">> }) ->
+  {error, {conflict, revision_conflict}}.
 
 %% @doc get all revisions ids that differ in a doc from the list given
 -spec revsdiff(Conn, DocId, RevIds) -> Res when

--- a/apps/barrel_httpc/src/barrel_httpc_fold.erl
+++ b/apps/barrel_httpc/src/barrel_httpc_fold.erl
@@ -75,7 +75,6 @@ changes_since(#{pool := Pool}= Conn, Since, Fun, AccIn, Options) ->
   ReqOpts = [{async, once}, {pool, Pool}],
   case hackney:request(<<"GET">>, Url, Headers, <<>>, ReqOpts) of
     {ok, Ref} ->
-      error_logger:info_msg("wait resp on ~p~n", [Url]),
       wait_fold_response(Ref, Fun, AccIn);
     Error ->
       Error

--- a/apps/barrel_store/src/barrel_db.erl
+++ b/apps/barrel_store/src/barrel_db.erl
@@ -19,8 +19,6 @@
 %% API
 -export([
   infos/1,
-  create_doc/3,
-  update_doc/3,
   get/3,
   multi_get/5,
   get_doc_info/3,
@@ -34,7 +32,8 @@
   delete_system_doc/2,
   query/5,
   query/6,
-  get_doc1/7
+  get_doc1/7,
+  update_docs/2
 ]).
 
 -export([
@@ -227,46 +226,12 @@ get_doc_info_int(#db{store=Store}, DocId, ReadOptions) ->
       {error, not_found}
   end.
 
-
-create_doc(DbName, Doc, Options0) ->
-  Options1 = [{create_if_missing, true} | Options0],
-  update_doc(DbName, Doc, Options1).
-
-update_doc(DbName, Doc, Options) ->
-  case update_docs(DbName, [Doc], Options) of
-    ok -> ok;
-    [Res] -> Res
-  end.
-
-prepare_docs(
-  [Doc | Rest], DocBuckets, Async, WithConflict, CreateIfMissing, ErrorIfExists, Ref, Idx
-) ->
-  Req = {self(), Ref, Idx, Async},
-  Update = {Doc, WithConflict, CreateIfMissing, ErrorIfExists, Req},
-
-  DocBuckets2 = case maps:find(Doc#doc.id, DocBuckets) of
-                  {ok, OldUpdates} -> maps:put(Doc#doc.id,  OldUpdates ++ [Update], DocBuckets);
-                  error -> maps:put(Doc#doc.id,  [Update], DocBuckets)
-                end,
-
-  prepare_docs(Rest, DocBuckets2, Async, WithConflict, CreateIfMissing, ErrorIfExists, Ref, Idx + 1);
-prepare_docs([], DocBuckets, _, _, _, _, _, Idx) ->
-  {DocBuckets, Idx}.
-
-update_docs(DbName, Docs, Options) ->
+update_docs(DbName, Batch) ->
   case barrel_store:whereis_db(DbName) of
     undefined -> {error, not_found};
     Db = #db{pid=DbPid} ->
-      Async = proplists:get_value(async, Options, false),
-      WithConflict = proplists:get_value(with_conflict, Options, false),
-      CreateIfMissing = proplists:get_value(create_if_missing, Options, false),
-      ErrorIfExists = proplists:get_value(error_if_exists, Options, false),
       
-      Ref = make_ref(),
-      % group docs by docid, in case of duplicates
-      {DocBuckets, N} = prepare_docs(
-        Docs, #{}, Async, WithConflict, CreateIfMissing, ErrorIfExists, Ref, 0
-      ),
+      {DocBuckets, Ref, Async, N} = barrel_write_batch:to_buckets(Batch),
       MRef = erlang:monitor(process, DbPid),
       DbPid ! {update_docs, DocBuckets},
 

--- a/apps/barrel_store/src/barrel_db.erl
+++ b/apps/barrel_store/src/barrel_db.erl
@@ -442,7 +442,6 @@ delete_system_doc(DbName, DocId) ->
     end
   ).
 
-
 query(DbName, Path, Fun, AccIn, Options) ->
   query(DbName, Path, Fun, AccIn, order_by_key, Options).
 

--- a/apps/barrel_store/src/barrel_local.erl
+++ b/apps/barrel_store/src/barrel_local.erl
@@ -257,7 +257,8 @@ update_doc(Db, Batch) ->
     [Res] -> Res
   end.
 
-
+%% @doc Apply the specified updates to the database.
+%% Note: The batch is not guaranteed to be atomic, atomicity is only guaranteed at the doc level.
 -spec write_batch(Db, Updates, Options) -> Results when
   Db :: db(),
   Updates :: [barrel_write_batch:batch_op()],

--- a/apps/barrel_store/src/barrel_write_batch.erl
+++ b/apps/barrel_store/src/barrel_write_batch.erl
@@ -1,0 +1,82 @@
+%%%-------------------------------------------------------------------
+%%% @author benoitc
+%%% @copyright (C) 2017, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 08. Mar 2017 22:16
+%%%-------------------------------------------------------------------
+-module(barrel_write_batch).
+-author("benoitc").
+
+%% API
+-export([
+  new/1,
+  put/3,
+  post/3,
+  delete/3,
+  put_rev/4,
+  to_buckets/1
+]).
+
+-include_lib("barrel_common/include/barrel_common.hrl").
+
+new(Async) ->
+  {#{}, self(), make_ref(), Async, 0}.
+
+put(Obj, Rev, Batch) ->
+  ok = validate_docid(Obj),
+  Doc = barrel_doc:make_doc(Obj, [Rev], false),
+  Req = make_req(Batch),
+  Op = make_op(Doc, Req, false, false, false),
+  update_batch(Doc#doc.id, Op, Batch).
+
+post(Obj0, IsUpsert, Batch) ->
+  %% maybe create the doc id
+  Obj1 = case barrel_doc:id(Obj0) of
+            undefined ->
+              Obj0#{ <<"id">> => barrel_lib:uniqid() };
+            _Id ->
+              Obj0
+          end,
+  %% create doc record
+  Doc = barrel_doc:make_doc(Obj1, [<<>>], false),
+  %% update the batch
+  ErrorIfExists = (IsUpsert =:= false),
+  Req = make_req(Batch),
+  Op = make_op(Doc, Req, false, true, ErrorIfExists),
+  update_batch(Doc#doc.id, Op, Batch).
+
+delete(DocId, Rev, Batch) when is_binary(DocId) ->
+  Doc = barrel_doc:make_doc(#{<<"id">> => DocId}, [Rev], true),
+  Req = make_req(Batch),
+  Op = make_op(Doc, Req, false, false, false),
+  update_batch(Doc#doc.id, Op, Batch).
+
+put_rev(Obj, History, Deleted, Batch) ->
+  ok = validate_docid(Obj),
+  Doc = barrel_doc:make_doc(Obj, History, Deleted),
+  Req = make_req(Batch),
+  Op = make_op(Doc, Req, true, false, false),
+  update_batch(Doc#doc.id, Op, Batch).
+
+to_buckets({DocBuckets, _, Ref, Async, N}) -> {DocBuckets, Ref, Async, N}.
+
+make_req({_DocBuckets, Client, Ref, Async, Idx}) ->
+  {Client, Ref, Idx, Async}.
+
+make_op(Doc, Req, WithConflict, CreateIfMissing, ErrorIfExists) ->
+  {Doc, WithConflict, CreateIfMissing, ErrorIfExists, Req}.
+
+update_batch(Id, Op, {DocBuckets, Client, Ref, Async, Idx}) ->
+  DocBuckets2 = case maps:find(Id, DocBuckets) of
+                  {ok, OldUpdates} ->
+                    maps:put(Id,  OldUpdates ++ [Op], DocBuckets);
+                  error ->
+                    maps:put(Id, [Op], DocBuckets)
+                end,
+  { DocBuckets2, Client, Ref, Async, Idx +1 }.
+
+%% internal
+validate_docid(#{ <<"id">> := _DocId }) -> ok;
+validate_docid(_) -> erlang:error({bad_doc, invalid_docid}).

--- a/apps/barrel_store/src/barrel_write_batch.erl
+++ b/apps/barrel_store/src/barrel_write_batch.erl
@@ -27,7 +27,7 @@
 -type batch_op() :: {put, Doc :: barrel_local:doc(), Rev :: barrel_local:revid()} |
                     {post, Doc :: barrel_local:doc(), IsUpsert :: boolean()} |
                     {delete, DocId :: barrel_local:docid(), Rev :: barrel_local:revid()} |
-                    {post, Doc :: barrel_local:doc(), History :: list(), Deleted :: boolean()} |
+                    {put_rev, Doc :: barrel_local:doc(), History :: list(), Deleted :: boolean()} |
                     map().
 
 -export_type([

--- a/apps/barrel_store/src/barrel_write_batch.erl
+++ b/apps/barrel_store/src/barrel_write_batch.erl
@@ -16,14 +16,36 @@
   post/3,
   delete/3,
   put_rev/4,
-  to_buckets/1
+  to_buckets/1,
+  from_list/2,
+  is_batch/1
 ]).
 
 -include_lib("barrel_common/include/barrel_common.hrl").
 
+-type batch() :: tuple().
+-type batch_op() :: {put, Doc :: barrel_local:doc(), Rev :: barrel_local:revid()} |
+                    {post, Doc :: barrel_local:doc(), IsUpsert :: boolean()} |
+                    {delete, DocId :: barrel_local:docid(), Rev :: barrel_local:revid()} |
+                    {post, Doc :: barrel_local:doc(), History :: list(), Deleted :: boolean()} |
+                    map().
+
+-export_type([
+  batch/0,
+  batch_op/0
+]).
+
+-spec new(Async) -> Batch when
+  Async :: boolean(),
+  Batch :: batch().
 new(Async) ->
   {#{}, self(), make_ref(), Async, 0}.
 
+-spec put(Obj, Rev, BatchIn) -> BatchOut when
+  Obj :: barrel_local:doc(),
+  Rev :: barrel_local:revid(),
+  BatchIn :: batch(),
+  BatchOut :: batch().
 put(Obj, Rev, Batch) ->
   ok = validate_docid(Obj),
   Doc = barrel_doc:make_doc(Obj, [Rev], false),
@@ -31,6 +53,11 @@ put(Obj, Rev, Batch) ->
   Op = make_op(Doc, Req, false, false, false),
   update_batch(Doc#doc.id, Op, Batch).
 
+-spec post(Obj, IsUpsert, BatchIn) -> BatchOut when
+  Obj :: barrel_local:doc(),
+  IsUpsert :: boolean(),
+  BatchIn :: batch(),
+  BatchOut :: batch().
 post(Obj0, IsUpsert, Batch) ->
   %% maybe create the doc id
   Obj1 = case barrel_doc:id(Obj0) of
@@ -47,12 +74,24 @@ post(Obj0, IsUpsert, Batch) ->
   Op = make_op(Doc, Req, false, true, ErrorIfExists),
   update_batch(Doc#doc.id, Op, Batch).
 
+
+-spec delete(DocId, Rev, BatchIn) -> BatchOut when
+  DocId :: barrel_local:docid(),
+  Rev :: barrel_local:revid(),
+  BatchIn :: batch(),
+  BatchOut :: batch().
 delete(DocId, Rev, Batch) when is_binary(DocId) ->
   Doc = barrel_doc:make_doc(#{<<"id">> => DocId}, [Rev], true),
   Req = make_req(Batch),
   Op = make_op(Doc, Req, false, false, false),
   update_batch(Doc#doc.id, Op, Batch).
 
+-spec put_rev(Obj, History, Deleted, BatchIn) -> BatchOut when
+  Obj :: barrel_local:doc(),
+  History :: barrel_local:list(),
+  Deleted :: boolean(),
+  BatchIn :: batch(),
+  BatchOut :: batch().
 put_rev(Obj, History, Deleted, Batch) ->
   ok = validate_docid(Obj),
   Doc = barrel_doc:make_doc(Obj, History, Deleted),
@@ -60,10 +99,69 @@ put_rev(Obj, History, Deleted, Batch) ->
   Op = make_op(Doc, Req, true, false, false),
   update_batch(Doc#doc.id, Op, Batch).
 
+-spec to_buckets(Batch) -> {DocBuckets, Ref, Async, N} when
+  Batch :: batch(),
+  DocBuckets :: list(),
+  Ref :: reference(),
+  Async :: boolean(),
+  N :: non_neg_integer().
 to_buckets({DocBuckets, _, Ref, Async, N}) -> {DocBuckets, Ref, Async, N}.
+
 
 make_req({_DocBuckets, Client, Ref, Async, Idx}) ->
   {Client, Ref, Idx, Async}.
+
+-spec from_list(OPs, Async) -> Batch when
+  OPs :: [batch_op()],
+  Async :: boolean(),
+  Batch :: batch().
+from_list(OPs, Async) ->
+  from_list_1(OPs, barrel_write_batch:new(Async)).
+
+
+from_list_1([Op | Rest], Batch) ->
+  case parse_op(Op) of
+    {put, Obj, Rev} ->
+      Batch2 = barrel_write_batch:put(Obj, Rev, Batch),
+      from_list_1(Rest, Batch2);
+    {post, Obj, IsUpsert} ->
+      Batch2 = barrel_write_batch:post(Obj, IsUpsert, Batch),
+      from_list_1(Rest, Batch2);
+    {delete, Id, Rev} ->
+      Batch2 = barrel_write_batch:delete(Id, Rev, Batch),
+      from_list_1(Rest, Batch2);
+    {put_rev, Obj, History, Deleted} ->
+      Batch2 = barrel_write_batch:put_rev(Obj, History, Deleted, Batch),
+      from_list_1(Rest, Batch2)
+  end;
+from_list_1([], Batch) ->
+  Batch.
+
+is_batch({_, _, _, _, _}) -> true;
+is_batch(_) -> false.
+
+%% expected ops coming from the API
+parse_op(#{ <<"op">> := <<"put">>, <<"doc">> := Doc} = OP) ->
+  Rev = maps:get(<<"rev">>, OP, <<>>),
+  {put, Doc, Rev};
+parse_op(#{ <<"op">> := <<"post">>, <<"doc">> := Doc} = OP) ->
+  IsUpsert = maps:get(<<"is_upsert">>, OP, false),
+  {post, Doc, IsUpsert};
+parse_op(#{ <<"op">> := <<"delete">>, <<"id">> := DocId} = OP) ->
+  Rev = maps:get(<<"rev">>, OP, <<>>),
+  {delete, DocId, Rev};
+parse_op(#{ <<"op">> := <<"put_rev">>, <<"doc">> := Doc, <<"history">> := History} = OP) ->
+  Deleted = maps:get(<<"deleted">>, OP, false),
+  {put_rev, Doc, History, Deleted};
+
+%% internal batch
+parse_op({put, Doc, Rev} = OP) when is_map(Doc), is_binary(Rev) -> OP;
+parse_op({post, Doc, IsUpsert} = OP) when is_map(Doc), is_boolean(IsUpsert) -> OP;
+parse_op({delete, Id, Rev} = OP) when is_binary(Id), is_binary(Rev) -> OP;
+parse_op({put_rev, Doc, History, Deleted} = OP)  when is_map(Doc), is_list(History), is_boolean(Deleted) -> OP;
+
+parse_op(_) -> erlang:error(badarg).
+
 
 make_op(Doc, Req, WithConflict, CreateIfMissing, ErrorIfExists) ->
   {Doc, WithConflict, CreateIfMissing, ErrorIfExists, Req}.
@@ -77,6 +175,6 @@ update_batch(Id, Op, {DocBuckets, Client, Ref, Async, Idx}) ->
                 end,
   { DocBuckets2, Client, Ref, Async, Idx +1 }.
 
-%% internal
+%% validate docid
 validate_docid(#{ <<"id">> := _DocId }) -> ok;
 validate_docid(_) -> erlang:error({bad_doc, invalid_docid}).

--- a/apps/barrel_store/src/barrel_write_batch.erl
+++ b/apps/barrel_store/src/barrel_write_batch.erl
@@ -24,7 +24,9 @@
 -include_lib("barrel_common/include/barrel_common.hrl").
 
 -type batch() :: tuple().
--type batch_op() :: {put, Doc :: barrel_local:doc(), Rev :: barrel_local:revid()} |
+-type batch_op() :: {put, Doc :: barrel_local:doc()} |
+                    {put, Doc :: barrel_local:doc(), Rev :: barrel_local:revid()} |
+                    {post, Doc :: barrel_local:doc()} |
                     {post, Doc :: barrel_local:doc(), IsUpsert :: boolean()} |
                     {delete, DocId :: barrel_local:docid(), Rev :: barrel_local:revid()} |
                     {put_rev, Doc :: barrel_local:doc(), History :: list(), Deleted :: boolean()} |
@@ -155,7 +157,9 @@ parse_op(#{ <<"op">> := <<"put_rev">>, <<"doc">> := Doc, <<"history">> := Histor
   {put_rev, Doc, History, Deleted};
 
 %% internal batch
+parse_op({put, Doc}) when is_map(Doc) -> {put, Doc, <<>>};
 parse_op({put, Doc, Rev} = OP) when is_map(Doc), is_binary(Rev) -> OP;
+parse_op({post, Doc}) when is_map(Doc) -> {post, Doc, false};
 parse_op({post, Doc, IsUpsert} = OP) when is_map(Doc), is_boolean(IsUpsert) -> OP;
 parse_op({delete, Id, Rev} = OP) when is_binary(Id), is_binary(Rev) -> OP;
 parse_op({put_rev, Doc, History, Deleted} = OP)  when is_map(Doc), is_list(History), is_boolean(Deleted) -> OP;


### PR DESCRIPTION
now supports batch via HTTP.

A batch is a JSON seent on Post with following headers and similar body:

Headers :

- `x-barrel-write-batch: true`
- `x-barrel-async: false`

JSON:

```json
{ "updates": [
  { "op": "put", "doc": {}, "rev": "" },
  { "op": "delete", "id": "someid", "rev": "" },
  { "op": "post", "doc": {} }
]}
```

Response is the following

if Async is true: `{ "ok" : true }`

Or following response

```json
{
  "ok": true,
  "results": [
     {"status": "ok", "id": "docid", "rev": "revid" },
  ]
}
```

Results can be

- ` {"status": "ok", "id": "docid", "rev": "revid" }`
- `{"status": "error", "reason": "not found" }`
-  `{"status": "conflict", "reason": "doc exists" }`
-  `{"status": "conflict", "reason": "revision conflic" }`

fix #57 