### PR TITLE
enable replication of doc with attachments

### DIFF
--- a/apps/barrel_replicate/src/barrel_replicate_alg.erl
+++ b/apps/barrel_replicate/src/barrel_replicate_alg.erl
@@ -72,7 +72,7 @@ write_doc(Target, Doc, History, Deleted, Metrics) ->
   end.
 
 get({Mod, ModState}, Id, Opts) ->
-  Mod:get(ModState, Id, Opts);
+  Mod:get(ModState, Id, [{attachments_parsing, false}|Opts]);
 get(Db, Id, Opts) when is_binary(Db) ->
   barrel_db:get(Db, Id, Opts).
 


### PR DESCRIPTION
Use the {attachments_parsing, false} options to read documents
with _attachments props
